### PR TITLE
Enable publishing of JUnit results by default

### DIFF
--- a/templates/android.yml
+++ b/templates/android.yml
@@ -12,6 +12,6 @@ steps:
     workingDirectory: ''
     gradleWrapperFile: 'gradlew'
     gradleOptions: '-Xmx3072m'
-    publishJUnitResults: false
+    publishJUnitResults: true
     testResultsFiles: '**/TEST-*.xml'
     tasks: 'assembleDebug'

--- a/templates/ant.yml
+++ b/templates/ant.yml
@@ -14,5 +14,5 @@ steps:
     javaHomeOption: 'JDKVersion'
     jdkVersionOption: '1.10'
     jdkArchitectureOption: 'x64'
-    publishJUnitResults: false
+    publishJUnitResults: true
     testResultsFiles: '**/TEST-*.xml'

--- a/templates/gradle.yml
+++ b/templates/gradle.yml
@@ -15,6 +15,6 @@ steps:
     javaHomeOption: 'JDKVersion'
     jdkVersionOption: '1.10'
     jdkArchitectureOption: 'x64'
-    publishJUnitResults: false
+    publishJUnitResults: true
     testResultsFiles: '**/TEST-*.xml'
     tasks: 'build'

--- a/templates/maven.yml
+++ b/templates/maven.yml
@@ -14,6 +14,6 @@ steps:
     javaHomeOption: 'JDKVersion'
     jdkVersionOption: '1.10'
     jdkArchitectureOption: 'x64'
-    publishJUnitResults: false
+    publishJUnitResults: true
     testResultsFiles: '**/surefire-reports/TEST-*.xml'
     goals: 'package'


### PR DESCRIPTION
I believe most of the pipeline templates publish test results by default, so I think the Java templates should do the same, unless there's a good reason not to.