### PR TITLE
Pipeline Artifacts proposal

### DIFF
--- a/design/pipeline-artifacts.md
+++ b/design/pipeline-artifacts.md
@@ -22,7 +22,7 @@ In this document, `artifact` and `downloadArtifact` refer specifically to Pipeli
 ### Example
 
 ```yaml
-- publishArtifact:
+- artifact:
   - **/bin/*
   - **/obj/*
   name: webapp
@@ -38,18 +38,16 @@ In this document, `artifact` and `downloadArtifact` refer specifically to Pipeli
 ### Schema
 
 ```yaml
-- downloadArtifacts:
-  - name: string # identifier for the artifact to download, optional; defaults to 'default'
-    patterns: string | [ string ] # a minimatch path or list of [minimatch paths](tasks/file-matching-patterns.md) to download; if blank, the entire artifact is downloaded
-    root: string # the directory in which to download files, defaults to $PIPELINES_RESOURCESDIR
-    resource: # the resource from which to download the artifact, defaults to self (indicating the current pipeline)
+- downloadArtifact: # identifier for the artifact to download, optional; defaults to 'default'
+  patterns: string | [ string ] # a minimatch path or list of [minimatch paths](tasks/file-matching-patterns.md) to download; if blank, the entire artifact is downloaded
+  root: string # the directory in which to download files, defaults to $PIPELINES_RESOURCESDIR
+  resource: # the resource from which to download the artifact, defaults to self (indicating the current pipeline)
 ```
 
 ### Example
 
 ```yaml
-- downloadArtifacts:
-  - name: webapp
+- downloadArtifact: webapp
 ```
 
 ---
@@ -92,9 +90,8 @@ You can control the location where artifacts are downloaded using the `downloadR
   - artifact: bin/*
 - job: Deploy
   steps:
-  - downloadArtifacts:
-    - name:
-      downloadRoot: $(Pipelines.SourcesDir)/from-build/
+  - downloadArtifact:
+    downloadRoot: $(Pipelines.SourcesDir)/from-build/
   - script: |
       TODO-some-cool-deploy-script-here $(Pipelines.SourcesDir)/from-build/bin/
 ```
@@ -137,9 +134,8 @@ You can give an artifact a name, and you can publish multiple named artifacts. A
     name: MobileApp
 - job: Deploy
   steps:
-  - downloadArtifacts:
-    - name: WebApp
-    - name: MobileApp
+  - downloadArtifact: WebApp
+  - downloadArtifact: MobileApp
   - script: TODO-some-cool-deploy-script-here $(Pipelines.ResourcesDir)/WebApp/bin/
   - script: TODO-xamarin-magic $(Pipelines.ResourcesDir)/MobileApp/
 ```

--- a/design/pipeline-artifacts.md
+++ b/design/pipeline-artifacts.md
@@ -1,0 +1,145 @@
+# Pipeline Artifacts YAML shortcut
+
+**Status: PM spec**
+
+Pipeline Artifacts are the new way to move files between jobs and stages in your pipeline. They are hosted in Azure Artifacts and will eventually entirely replace FCS "Build Artifacts". Because moving files between jobs and stages is a crucial part of most CI/CD workflows, and because Pipeline Artifacts are expected to be the default way to do so, this spec proposes a YAML shortcut syntax for publishing and downloading artifacts.
+
+In this document, `artifact` and `downloadArtifact` refer specifically to Pipeline Artifacts. Artifacts are distinct from `resources`, which are various kinds of inputs like `pipelines`, `containers`, `repositories`, and `packages`. Ashok is driving the YAML spec for these inputs, and he and I (amullans) are in sync.
+
+## Proposal: artifact
+
+`artifact` is a shortcut for the [Publish Pipeline Artifacts](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/publish-pipeline-artifact.md) task. It will publish files from the current job to be used in subsequent jobs or in other stages or pipelines.
+
+### Schema
+
+```yaml
+- artifact: string | [ string ]  # a minimatch path or list of [minimatch paths](tasks/file-matching-patterns.md) to publish
+  name: string # identifier for this artifact (no spaces allowed), defaults to 'default'
+  prependPath: string # a directory path that will be prepended to all published files
+  seal: boolean # if true, finalizes the artifact so no more files can be added after this step
+```
+
+### Example
+
+```yaml
+- publishArtifact:
+  - **/bin/*
+  - **/obj/*
+  name: webapp
+  seal: true
+```
+
+---
+
+## Proposal: downloadArtifact
+
+`downloadArtifact` is a shortcut for the [Download Pipeline Artifacts](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/download-pipeline-artifact.md) task. It will download artifacts published from a previous job or stage or from another pipeline. Artifacts are downloaded either to `$PIPELINES_RESOURCESDIR` or to the directory specified in `root`.
+
+### Schema
+
+```yaml
+- downloadArtifacts:
+  - name: string # identifier for the artifact to download, optional; defaults to 'default'
+    patterns: string | [ string ] # a minimatch path or list of [minimatch paths](tasks/file-matching-patterns.md) to download; if blank, the entire artifact is downloaded
+    root: string # the directory in which to download files, defaults to $PIPELINES_RESOURCESDIR
+    resource: # the resource from which to download the artifact, defaults to self (indicating the current pipeline)
+```
+
+### Example
+
+```yaml
+- downloadArtifacts:
+  - name: webapp
+```
+
+---
+
+## More details about Pipeline Artifacts
+
+### Default and named artifacts
+
+Every Pipeline run has a default artifact (named `default`). You can also create multiple artifacts, each with their own name. All artifacts (including `default`) are automatically downloaded to each subsequent job's resources directory (`$(Pipelines.ResourcesDir)`). You can limit the artifacts downloaded by adding a `downloadArtifact` step to the beginning of a job.
+
+### Multi-publish artifacts
+
+You can add files to any artifact multiple times in the same job, in different jobs in the same stage, and in different stages in the same pipeline, or you can `seal` an artifact at any time to prevent further files from being added.
+
+## Examples
+
+### Publish a build artifact and use it in a deployment
+
+This is a simple pipeline that include a build job and a deployment job. The built artifact is provided to the deployment job using the default Pipeline Artifact.
+
+```yaml
+- job: Build
+  steps:
+  - script: dotnet publish --configuration $(buildConfiguration)
+  - artifact: bin/*
+- job: Deploy
+  steps:
+  - script: |
+      TODO-some-cool-deploy-script-here $(Pipelines.ResourcesDir)/default/bin/
+```
+
+### Specify a custom location for a build artifact
+
+You can control the location where artifacts are downloaded using the `downloadRoot` key.
+
+```yaml
+- job: Build
+  steps:
+  - script: dotnet publish --configuration $(buildConfiguration)
+  - artifact: bin/*
+- job: Deploy
+  steps:
+  - downloadArtifacts:
+    - name:
+      downloadRoot: $(Pipelines.SourcesDir)/from-build/
+  - script: |
+      TODO-some-cool-deploy-script-here $(Pipelines.SourcesDir)/from-build/bin/
+```
+
+### Add to an artifact multiple times
+
+You can add files to both the default artifact and to named artifacts until the end of the pipeline or until a `artifacts` step is run with the `seal` key set to `true`.
+
+```yaml
+- job: Build .NET Core
+  steps:
+  - script: dotnet publish --configuration $(buildConfiguration)
+  - artifact: bin/*
+    prependPath: netcore/
+- job: Build .NET Framework
+  steps:
+    - task: VSBuild@1
+      inputs:
+        solution: MySolution.sln
+    - artifact: bin/*
+      prependPath: netfx/
+      seal: true
+- job: Deploy .NET Core
+  steps:
+  - script: |
+      TODO-some-cool-deploy-script-here $(Pipelines.ResourcesDir)/default/netcore/bin/
+```
+
+### Publish a named artifact
+
+You can give an artifact a name, and you can publish multiple named artifacts. All artifacts are downloaded unless you specify a `downloadArtifact` step to limit the artifacts that are downloaded.
+
+```yaml
+- job: Build
+  steps:
+  - script: dotnet publish --configuration $(buildConfiguration)
+  - artifact: bin/WebApp/*
+    name: WebApp
+  - artifact: bin/MobileApp/*
+    name: MobileApp
+- job: Deploy
+  steps:
+  - downloadArtifacts:
+    - name: WebApp
+    - name: MobileApp
+  - script: TODO-some-cool-deploy-script-here $(Pipelines.ResourcesDir)/WebApp/bin/
+  - script: TODO-xamarin-magic $(Pipelines.ResourcesDir)/MobileApp/
+```

--- a/design/pipeline-artifacts.md
+++ b/design/pipeline-artifacts.md
@@ -4,7 +4,7 @@
 
 Pipeline Artifacts are the new way to move files between jobs and stages in your pipeline. They are hosted in Azure Artifacts and will eventually entirely replace FCS "Build Artifacts". Because moving files between jobs and stages is a crucial part of most CI/CD workflows, and because Pipeline Artifacts are expected to be the default way to do so, this spec proposes a YAML shortcut syntax for publishing and downloading artifacts.
 
-In this document, `artifact` and `downloadArtifact` refer specifically to Pipeline Artifacts. Artifacts are distinct from `resources`, which are various kinds of inputs like `pipelines`, `containers`, `repositories`, and `packages`. Ashok is driving the YAML spec for these inputs, and he and I (amullans) are in sync.
+In this document, `artifact` and `downloadArtifact` refer specifically to Pipeline Artifacts. Artifacts are distinct from `resources`, which are various kinds of inputs like `containers`, `repositories`, and `feeds`.
 
 ## Proposal: artifact
 
@@ -35,52 +35,22 @@ In this document, `artifact` and `downloadArtifact` refer specifically to Pipeli
 
 `downloadArtifact` is a shortcut for the [Download Pipeline Artifacts](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/download-pipeline-artifact.md) task. It will download artifacts published from a previous job or stage or from another pipeline. Artifacts are downloaded either to `$PIPELINES_RESOURCESDIR` or to the directory specified in `root`.
 
-### Option 1: fewer lines
-
-#### Schema
-
-```yaml
-- downloadArtifact: string # identifier for the artifact to download, optional; defaults to 'default'
-  patterns: string | [ string ] # a minimatch path or list of [minimatch paths](tasks/file-matching-patterns.md) to download; if blank, the entire artifact is downloaded
-  root: string # the directory in which to download files, defaults to $PIPELINES_RESOURCESDIR
-
-- downloadPipeline: string # identifier for the pipeline to download
-  artifacts: string | [ string ] # identifier(s) for the artifacts to download
-  patterns: string | [ string ] # a minimatch path or list of [minimatch paths](tasks/file-matching-patterns.md) to download; if blank, the entire artifact is downloaded
-  version: string # the run/version of the pipeline to get artifacts from
-```
-
-#### Example
-
-```yaml
-- downloadArtifact: webapp
-- downloadPipeline: P2
-  artifacts: p1
-  version: 2
-```
-
-### Option 2: fewer keywords
-
-#### Schema
+### Schema
 
 ```yaml
 - downloadArtifact: string # identifier for the pipeline from which to download artifacts, optional; defaults to 'self'
   name: string # identifier for the artifact to download
   patterns: string | [ string ] # a minimatch path or list of [minimatch paths](tasks/file-matching-patterns.md) to download; if blank, the entire artifact is downloaded
   root: string # the directory in which to download files, defaults to $PIPELINES_RESOURCESDIR
-  version: string # the run/version of the pipeline to get artifacts from
+  version: string # the run ID to get artifacts from. If `self`, defaults to the current run; if another pipeline, defaults to the latest successful run
 ```
 
-### Option 3: multi-artifact in one step
-
-#### Schema
+### Examples
 
 ```yaml
-- downloadArtifacts: string # identifier for the pipeline from which to download artifacts, optional; defaults to 'self'
-  version: string # the run/version of the pipeline to get artifacts from
-  - artifact: string # identifier for the artifact to download
-    patterns: string | [ string ] # a minimatch path or list of [minimatch paths](tasks/file-matching-patterns.md) to download; if blank, the entire artifact is downloaded
-    root: string # the directory in which to download files, defaults to $PIPELINES_RESOURCESDIR
+- downloadArtifact:
+  name: webapp
+- downloadArtifact: tools-pipeline
 ```
 
 ## More details about Pipeline Artifacts

--- a/design/pipeline-artifacts.md
+++ b/design/pipeline-artifacts.md
@@ -4,7 +4,7 @@
 
 Pipeline Artifacts are the new way to move files between jobs and stages in your pipeline. They are hosted in Azure Artifacts and will eventually entirely replace FCS "Build Artifacts". Because moving files between jobs and stages is a crucial part of most CI/CD workflows, and because Pipeline Artifacts are expected to be the default way to do so, this spec proposes a YAML shortcut syntax for publishing and downloading artifacts.
 
-In this document, `artifact` and `downloadArtifact` refer specifically to Pipeline Artifacts. Artifacts are distinct from `resources`, which are various kinds of inputs like `containers`, `repositories`, and `feeds`.
+In this document, `artifact` and `downloadArtifact` refer specifically to Pipeline Artifacts (TODO and possibly artifacts from other pipeline resources). Artifacts are distinct from `resources`, which are various kinds of inputs like `containers`, `repositories`, and `feeds`.
 
 ## Proposal: artifact
 
@@ -33,7 +33,7 @@ In this document, `artifact` and `downloadArtifact` refer specifically to Pipeli
 
 ## Proposal: downloadArtifact
 
-`downloadArtifact` is a shortcut for the [Download Pipeline Artifacts](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/download-pipeline-artifact.md) task. It will download artifacts published from a previous job or stage or from another pipeline. Artifacts are downloaded either to `$PIPELINES_RESOURCESDIR` or to the directory specified in `root`.
+`downloadArtifact` is a shortcut for the [Download Pipeline Artifacts](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/download-pipeline-artifact.md) (TODO and possibly other tasks for e.g. Jenkins) task. It will download artifacts published from a previous job or stage or from another pipeline. Artifacts are downloaded either to `$PIPELINES_RESOURCESDIR` or to the directory specified in `root`.
 
 ### Schema
 

--- a/design/pipeline-artifacts.md
+++ b/design/pipeline-artifacts.md
@@ -35,22 +35,53 @@ In this document, `artifact` and `downloadArtifact` refer specifically to Pipeli
 
 `downloadArtifact` is a shortcut for the [Download Pipeline Artifacts](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/download-pipeline-artifact.md) task. It will download artifacts published from a previous job or stage or from another pipeline. Artifacts are downloaded either to `$PIPELINES_RESOURCESDIR` or to the directory specified in `root`.
 
-### Schema
+### Option 1: fewer lines
+
+#### Schema
 
 ```yaml
-- downloadArtifact: # identifier for the artifact to download, optional; defaults to 'default'
+- downloadArtifact: string # identifier for the artifact to download, optional; defaults to 'default'
   patterns: string | [ string ] # a minimatch path or list of [minimatch paths](tasks/file-matching-patterns.md) to download; if blank, the entire artifact is downloaded
   root: string # the directory in which to download files, defaults to $PIPELINES_RESOURCESDIR
-  resource: # the resource from which to download the artifact, defaults to self (indicating the current pipeline)
+
+- downloadPipeline: string # identifier for the pipeline to download
+  artifacts: string | [ string ] # identifier(s) for the artifacts to download
+  patterns: string | [ string ] # a minimatch path or list of [minimatch paths](tasks/file-matching-patterns.md) to download; if blank, the entire artifact is downloaded
+  version: string # the run/version of the pipeline to get artifacts from
 ```
 
-### Example
+#### Example
 
 ```yaml
 - downloadArtifact: webapp
+- downloadPipeline: P2
+  artifacts: p1
+  version: 2
 ```
 
----
+### Option 2: fewer keywords
+
+#### Schema
+
+```yaml
+- downloadArtifact: string # identifier for the pipeline from which to download artifacts, optional; defaults to 'self'
+  name: string # identifier for the artifact to download
+  patterns: string | [ string ] # a minimatch path or list of [minimatch paths](tasks/file-matching-patterns.md) to download; if blank, the entire artifact is downloaded
+  root: string # the directory in which to download files, defaults to $PIPELINES_RESOURCESDIR
+  version: string # the run/version of the pipeline to get artifacts from
+```
+
+### Option 3: multi-artifact in one step
+
+#### Schema
+
+```yaml
+- downloadArtifacts: string # identifier for the pipeline from which to download artifacts, optional; defaults to 'self'
+  version: string # the run/version of the pipeline to get artifacts from
+  - artifact: string # identifier for the artifact to download
+    patterns: string | [ string ] # a minimatch path or list of [minimatch paths](tasks/file-matching-patterns.md) to download; if blank, the entire artifact is downloaded
+    root: string # the directory in which to download files, defaults to $PIPELINES_RESOURCESDIR
+```
 
 ## More details about Pipeline Artifacts
 

--- a/design/pipeline-artifacts.md
+++ b/design/pipeline-artifacts.md
@@ -1,12 +1,14 @@
 # Pipeline Artifacts YAML shortcut
 
-**Status: PM spec**
+**Status: Awaiting final review**
 
 Pipeline Artifacts are the new way to move files between jobs and stages in your pipeline. They are hosted in Azure Artifacts and will eventually entirely replace FCS "Build Artifacts". Because moving files between jobs and stages is a crucial part of most CI/CD workflows, and because Pipeline Artifacts are expected to be the default way to do so, this spec proposes a YAML shortcut syntax for publishing and downloading artifacts.
 
-In this document, `artifact` and `downloadArtifact` refer specifically to Pipeline Artifacts (TODO and possibly artifacts from other pipeline resources). Artifacts are distinct from `resources`, which are various kinds of inputs like `containers`, `repositories`, and `feeds`.
+In this document, `artifact` refers specifically to publishing Pipeline Artifacts from the current pipeline. `downloadArtifact` refers to downloading Pipeline Artifact artifacts from the current pipeline, from other Azure Pipelines, and from other pipeline resources (e.g. Jenkins builds). 
 
-## Proposal: artifact
+Artifacts are distinct from other `resources` types, including `containers`, `repositories`, and `feeds`.
+
+## Publishing artifacts: `artifact`
 
 `artifact` is a shortcut for the [Publish Pipeline Artifacts](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/publish-pipeline-artifact.md) task. It will publish files from the current job to be used in subsequent jobs or in other stages or pipelines.
 
@@ -31,18 +33,23 @@ In this document, `artifact` and `downloadArtifact` refer specifically to Pipeli
 
 ---
 
-## Proposal: downloadArtifact
+## Downloading artifacts: `downloadArtifact`
 
-`downloadArtifact` is a shortcut for the [Download Pipeline Artifacts](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/download-pipeline-artifact.md) (TODO and possibly other tasks for e.g. Jenkins) task. It will download artifacts published from a previous job or stage or from another pipeline. Artifacts are downloaded either to `$PIPELINES_RESOURCESDIR` or to the directory specified in `root`.
+`downloadArtifact` is a shortcut for several tasks:
+
+- The [Download Pipeline Artifacts](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/download-pipeline-artifact) task
+- The [Download Fileshare Artifacts](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/download-fileshare-artifacts) task
+- Download tasks for other pipelines systems e.g. Jenkins
+
+It will download artifacts published from a previous job or stage or from another pipeline. Artifacts are downloaded either to `$PIPELINES_RESOURCESDIR` or to the directory specified in `root`.
 
 ### Schema
 
 ```yaml
-- downloadArtifact: string # identifier for the pipeline from which to download artifacts, optional; defaults to 'self'
-  name: string # identifier for the artifact to download
+- downloadArtifact: string # identifier for the resource from which to download artifacts, optional; defaults to 'self`
+  name: string # identifier for the artifact to download; if left blank, downloads all artifacts associated with the resource provided
   patterns: string | [ string ] # a minimatch path or list of [minimatch paths](tasks/file-matching-patterns.md) to download; if blank, the entire artifact is downloaded
   root: string # the directory in which to download files, defaults to $PIPELINES_RESOURCESDIR
-  version: string # the run ID to get artifacts from. If `self`, defaults to the current run; if another pipeline, defaults to the latest successful run
 ```
 
 ### Examples
@@ -92,7 +99,7 @@ You can control the location where artifacts are downloaded using the `downloadR
 - job: Deploy
   steps:
   - downloadArtifact:
-    downloadRoot: $(Pipelines.SourcesDir)/from-build/
+    root: $(Pipelines.SourcesDir)/from-build/
   - script: |
       TODO-some-cool-deploy-script-here $(Pipelines.SourcesDir)/from-build/bin/
 ```


### PR DESCRIPTION
**(Note, below is the original PR text. For the best experience, start with "Files changed", which has the final proposal.)**

Moving this over from a private repo. Also separating out this proposal from the use/auth proposal (#40).

@ashokirla can you take a look at this and see if I've covered all your feedback? I looked at your Word doc and tried to hew as closely as possible to your `downloadArtifacts` section, but I couldn't do it 100% since you can't have a value and then a list (e.g. [1]). So, I instead propose providing the resource as a separate key (see line 43 of this file). Thoughts?

I think we're pretty close to locking this in, which means we can then schedule the work:
1. On Artifacts Core, ensuring the tasks support the options we want to expose here, and updating the tasks so that the key names match what we're proposing here (so that whether you use the task or the shortcut, you provide the same keys).
2. On CI Platform, implementing the `artifact` and `downloadArtifacts` shortcuts that call out to the tasks in (1.)

Anything I'm missing? Do we need any more review other than approving this PR and merging it into the design repo?

[1]
```yaml
  - downloadArtifacts: self
    artifactName: WebTier1
```