### PR TITLE
Trigger CI only on 'master' so that CI and PR builds don't both run for PR changes

### DIFF
--- a/templates/.net-desktop.yml
+++ b/templates/.net-desktop.yml
@@ -3,6 +3,9 @@
 # Add steps that publish symbols, save build artifacts, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/apps/windows/dot-net
 
+trigger:
+- master
+
 pool:
   vmImage: 'VS2017-Win2016'
 

--- a/templates/android.yml
+++ b/templates/android.yml
@@ -3,6 +3,9 @@
 # Add steps that test, sign, and distribute the APK, save build artifacts, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/languages/android
 
+trigger:
+- master
+
 pool:
   vmImage: 'macOS-10.13'
 

--- a/templates/ant.yml
+++ b/templates/ant.yml
@@ -3,6 +3,9 @@
 # Add steps that save build artifacts and more:
 # https://docs.microsoft.com/azure/devops/pipelines/languages/java
 
+trigger:
+- master
+
 pool:
   vmImage: 'Ubuntu-16.04'
 

--- a/templates/asp.net-core-.net-framework.yml
+++ b/templates/asp.net-core-.net-framework.yml
@@ -3,6 +3,9 @@
 # Add steps that publish symbols, save build artifacts, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/languages/dotnet-core
 
+trigger:
+- master
+
 pool:
   vmImage: 'VS2017-Win2016'
 

--- a/templates/asp.net-core.yml
+++ b/templates/asp.net-core.yml
@@ -3,6 +3,9 @@
 # Add steps that run tests, create a NuGet package, deploy, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/languages/dotnet-core
 
+trigger:
+- master
+
 pool:
   vmImage: 'Ubuntu-16.04'
 

--- a/templates/asp.net.yml
+++ b/templates/asp.net.yml
@@ -3,6 +3,9 @@
 # Add steps that publish symbols, save build artifacts, deploy, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/apps/aspnet/build-aspnet-4
 
+trigger:
+- master
+
 pool:
   vmImage: 'VS2017-Win2016'
 

--- a/templates/docker-container-to-acr.yml
+++ b/templates/docker-container-to-acr.yml
@@ -2,6 +2,9 @@
 # Build a Docker image and push to a container registry
 # https://docs.microsoft.com/azure/devops/pipelines/languages/docker
 
+trigger:
+- master
+
 resources:
 - repo: self
 

--- a/templates/docker-container-to-aks.yml
+++ b/templates/docker-container-to-aks.yml
@@ -2,6 +2,9 @@
 # Build a Docker image, push to a container registry and deploy to Azure kubernetes service
 # https://docs.microsoft.com/azure/devops/pipelines/languages/docker
 
+trigger:
+- master
+
 resources:
 - repo: self
 

--- a/templates/docker-container.yml
+++ b/templates/docker-container.yml
@@ -3,6 +3,9 @@
 # Add steps that use Docker Compose, tag images, push to a registry, run an image, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/languages/docker
 
+trigger:
+- master
+
 pool:
   vmImage: 'Ubuntu-16.04'
 

--- a/templates/empty.yml
+++ b/templates/empty.yml
@@ -3,6 +3,9 @@
 # Add steps that build, run tests, deploy, and more:
 # https://aka.ms/yaml
 
+trigger:
+- master
+
 pool:
   vmImage: 'Ubuntu-16.04'
 

--- a/templates/gcc.yml
+++ b/templates/gcc.yml
@@ -3,6 +3,9 @@
 # Add steps that publish test results, save build artifacts, deploy, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/apps/c-cpp/gcc
 
+trigger:
+- master
+
 pool:
   vmImage: 'Ubuntu-16.04'
 

--- a/templates/go.yml
+++ b/templates/go.yml
@@ -3,6 +3,9 @@
 # Add steps that test, save build artifacts, deploy, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/languages/go
 
+trigger:
+- master
+
 pool:
   vmImage: 'Ubuntu-16.04'
 

--- a/templates/gradle.yml
+++ b/templates/gradle.yml
@@ -3,6 +3,9 @@
 # Add steps that analyze code, save build artifacts, deploy, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/languages/java
 
+trigger:
+- master
+
 pool:
   vmImage: 'Ubuntu-16.04'
 

--- a/templates/html.yml
+++ b/templates/html.yml
@@ -3,6 +3,9 @@
 # Add steps that build, run tests, deploy, and more:
 # https://aka.ms/yaml
 
+trigger:
+- master
+
 pool:
   vmImage: 'Ubuntu-16.04'
 

--- a/templates/jekyll-container.yml
+++ b/templates/jekyll-container.yml
@@ -3,6 +3,9 @@
 # Add steps that build, test, save build artifacts, deploy, and more:
 # https://aka.ms/yaml
 
+trigger:
+- master
+
 pool:
   vmImage: 'Ubuntu-16.04'
 

--- a/templates/maven.yml
+++ b/templates/maven.yml
@@ -3,6 +3,9 @@
 # Add steps that analyze code, save build artifacts, deploy, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/languages/java
 
+trigger:
+- master
+
 pool:
   vmImage: 'Ubuntu-16.04'
 

--- a/templates/node.js-with-angular.yml
+++ b/templates/node.js-with-angular.yml
@@ -3,6 +3,9 @@
 # Add steps that analyze code, save build artifacts, deploy, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/languages/javascript
 
+trigger:
+- master
+
 pool:
   vmImage: 'Ubuntu-16.04'
 

--- a/templates/node.js-with-grunt.yml
+++ b/templates/node.js-with-grunt.yml
@@ -3,6 +3,9 @@
 # Add steps that analyze code, save build artifacts, deploy, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/languages/javascript
 
+trigger:
+- master
+
 pool:
   vmImage: 'Ubuntu-16.04'
 

--- a/templates/node.js-with-gulp.yml
+++ b/templates/node.js-with-gulp.yml
@@ -3,6 +3,9 @@
 # Add steps that analyze code, save build artifacts, deploy, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/languages/javascript
 
+trigger:
+- master
+
 pool:
   vmImage: 'Ubuntu-16.04'
 

--- a/templates/node.js-with-react.yml
+++ b/templates/node.js-with-react.yml
@@ -3,6 +3,9 @@
 # Add steps that analyze code, save build artifacts, deploy, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/languages/javascript
 
+trigger:
+- master
+
 pool:
   vmImage: 'Ubuntu-16.04'
 

--- a/templates/node.js-with-vue.yml
+++ b/templates/node.js-with-vue.yml
@@ -3,6 +3,9 @@
 # Add steps that analyze code, save build artifacts, deploy, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/languages/javascript
 
+trigger:
+- master
+
 pool:
   vmImage: 'Ubuntu-16.04'
 

--- a/templates/node.js-with-webpack.yml
+++ b/templates/node.js-with-webpack.yml
@@ -3,6 +3,9 @@
 # Add steps that analyze code, save build artifacts, deploy, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/languages/javascript
 
+trigger:
+- master
+
 pool:
   vmImage: 'Ubuntu-16.04'
 

--- a/templates/node.js.yml
+++ b/templates/node.js.yml
@@ -3,6 +3,9 @@
 # Add steps that analyze code, save build artifacts, deploy, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/languages/javascript
 
+trigger:
+- master
+
 pool:
   vmImage: 'Ubuntu-16.04'
 

--- a/templates/php.yml
+++ b/templates/php.yml
@@ -3,6 +3,9 @@
 # Add steps that run tests, save build artifacts, deploy, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/languages/php
 
+trigger:
+- master
+
 pool:
   vmImage: 'Ubuntu-16.04'
 

--- a/templates/python-django.yml
+++ b/templates/python-django.yml
@@ -3,6 +3,9 @@
 # Add steps that analyze code, save build artifacts, deploy, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/languages/python
 
+trigger:
+- master
+
 pool:
   vmImage: 'Ubuntu-16.04'
 strategy:

--- a/templates/python-package.yml
+++ b/templates/python-package.yml
@@ -3,6 +3,9 @@
 # Add steps that analyze code, save the dist with the build record, publish to a PyPI-compatible index, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/languages/python
 
+trigger:
+- master
+
 jobs:
 
 - job: 'Test'

--- a/templates/ruby.yml
+++ b/templates/ruby.yml
@@ -3,6 +3,9 @@
 # Add steps that install rails, analyze code, save build artifacts, deploy, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/languages/ruby
 
+trigger:
+- master
+
 pool:
   vmImage: 'Ubuntu-16.04'
 

--- a/templates/universal-windows-platform.yml
+++ b/templates/universal-windows-platform.yml
@@ -3,6 +3,9 @@
 # Add steps that test and distribute an app, save build artifacts, and more:
 # https://aka.ms/yaml
 
+trigger:
+- master
+
 pool:
   vmImage: 'VS2017-Win2016'
 

--- a/templates/xamarin.android.yml
+++ b/templates/xamarin.android.yml
@@ -3,6 +3,9 @@
 # Add steps that test, sign, and distribute an app, save build artifacts, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/languages/xamarin
 
+trigger:
+- master
+
 pool:
   vmImage: 'macOS-10.13'
 

--- a/templates/xamarin.ios.yml
+++ b/templates/xamarin.ios.yml
@@ -3,14 +3,18 @@
 # Add steps that install certificates, test, sign, and distribute an app, save build artifacts, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/languages/xamarin
 
+trigger:
+- master
+
 pool:
   vmImage: 'macOS-10.13'
 
 steps:
 # To manually select a Xamarin SDK version on the Microsoft-hosted macOS agent,
-# configure this task with the SDK version you want to target and set the "enabled" property to true.
+# configure this task with the *Mono* version that is associated with the
+# Xamarin SDK version that you need, and set the "enabled" property to true.
 # See https://go.microsoft.com/fwlink/?linkid=871629
-- script: sudo $AGENT_HOMEDIRECTORY/scripts/select-xamarin-sdk.sh 5_4_1 
+- script: sudo $AGENT_HOMEDIRECTORY/scripts/select-xamarin-sdk.sh 5_12_0
   displayName: 'Select the Xamarin SDK version'
   enabled: false
 

--- a/templates/xcode.yml
+++ b/templates/xcode.yml
@@ -3,6 +3,9 @@
 # Add steps that install certificates, test, sign, and distribute an app, save build artifacts, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/languages/xcode
 
+trigger:
+- master
+
 pool:
   vmImage: 'macOS-10.13'
 


### PR DESCRIPTION
Let's say you use one of our YAML templates to add azure-pipelines.yml to your repo.  Later on, someone creates a new PR.  For every change committed to that PR, you'll get both a CI and a PR build.  It's because if no CI trigger is specified in the YAML, CI fires for every branch - PR or not.

This PR adds to each YAML template an explicit CI trigger for 'master' .  This results in users getting PR builds, and upon merging - a CI build.  But not both at the same time for a PR commit.