### PR TITLE
fix to ignore dot files to copy

### DIFF
--- a/templates/go.yml
+++ b/templates/go.yml
@@ -21,6 +21,7 @@ steps:
     mkdir -p '$(GOPATH)/pkg'
     mkdir -p '$(modulePath)'
     shopt -s extglob
+    shopt -s dotglob
     mv !(gopath) '$(modulePath)'
     echo '##vso[task.prependpath]$(GOBIN)'
     echo '##vso[task.prependpath]$(GOROOT)/bin'


### PR DESCRIPTION
This PR is related this issue. https://developercommunity.visualstudio.com/content/problem/420440/go-template-ignore-dot-files.html
The current go template ignore the dot files. like .foo. It copys Go files however, it doesn't work if they require the dot files.
Since I'm not sure if you have some intent for not using dotglob, I just want to share the issue and hopefully contribute it.

Also related this PR.

https://github.com/MicrosoftDocs/pipelines-go/pull/5
