### PR TITLE
Updating required inputs for templates

### DIFF
--- a/templates/docker-container-functionapp.properties.json
+++ b/templates/docker-container-functionapp.properties.json
@@ -1,7 +1,7 @@
 {
   "iconName": "functionapp",
   "requires": [ 
-    { "name" : "serviceEndpointId", "type": "connectedService:azureRM" },
-    { "name" : "repositoryName", "type": "string" }
+    { "name" : "serviceEndpointId", "type": "connectedService:azureRM", "required": "true" },
+    { "name" : "repositoryName", "type": "string", "required": "true" }
   ]
 }

--- a/templates/docker-container-functionapp.properties.json
+++ b/templates/docker-container-functionapp.properties.json
@@ -1,6 +1,6 @@
 {
   "iconName": "functionapp",
-  "requires": [ 
+  "parameters": [ 
     { "name" : "serviceEndpointId", "type": "connectedService:azureRM", "required": "true" },
     { "name" : "repositoryName", "type": "string", "required": "true" }
   ]

--- a/templates/docker-container-functionapp.properties.json
+++ b/templates/docker-container-functionapp.properties.json
@@ -1,4 +1,7 @@
 {
   "iconName": "functionapp",
-  "requires": [ "azuresubscription"]
+  "requires": [ 
+    { "name" : "serviceEndpointId", "type": "connectedService:azureRM" },
+    { "name" : "repositoryName", "type": "string" }
+  ]
 }

--- a/templates/docker-container-to-acr.properties.json
+++ b/templates/docker-container-to-acr.properties.json
@@ -1,6 +1,6 @@
 {
   "iconName": "docker",
-  "requires": [ 
+  "parameters": [ 
     { "name" : "serviceEndpointId", "type": "connectedService:azureRM", "required": "true" },
     { "name" : "repositoryName", "type": "string", "required": "true" }
   ]

--- a/templates/docker-container-to-acr.properties.json
+++ b/templates/docker-container-to-acr.properties.json
@@ -1,7 +1,7 @@
 {
   "iconName": "docker",
   "requires": [ 
-    { "name" : "serviceEndpointId", "type": "connectedService:azureRM" },
-    { "name" : "repositoryName", "type": "string" }
+    { "name" : "serviceEndpointId", "type": "connectedService:azureRM", "required": "true" },
+    { "name" : "repositoryName", "type": "string", "required": "true" }
   ]
 }

--- a/templates/docker-container-to-acr.properties.json
+++ b/templates/docker-container-to-acr.properties.json
@@ -1,4 +1,7 @@
 {
   "iconName": "docker",
-  "requires": [ "azuresubscription"]
+  "requires": [ 
+    { "name" : "serviceEndpointId", "type": "connectedService:azureRM" },
+    { "name" : "repositoryName", "type": "string" }
+  ]
 }

--- a/templates/docker-container-to-aks.properties.json
+++ b/templates/docker-container-to-aks.properties.json
@@ -1,7 +1,7 @@
 {
   "iconName": "aks",
   "requires": [ 
-    { "name" : "serviceEndpointId", "type": "connectedService:azureRM" },
-    { "name" : "repositoryName", "type": "string" }
+    { "name" : "serviceEndpointId", "type": "connectedService:azureRM", "required": "true" },
+    { "name" : "repositoryName", "type": "string", "required": "true" }
   ]
 }

--- a/templates/docker-container-to-aks.properties.json
+++ b/templates/docker-container-to-aks.properties.json
@@ -1,6 +1,6 @@
 {
   "iconName": "aks",
-  "requires": [ 
+  "parameters": [ 
     { "name" : "serviceEndpointId", "type": "connectedService:azureRM", "required": "true" },
     { "name" : "repositoryName", "type": "string", "required": "true" }
   ]

--- a/templates/docker-container-to-aks.properties.json
+++ b/templates/docker-container-to-aks.properties.json
@@ -1,4 +1,7 @@
 {
   "iconName": "aks",
-  "requires": [ "azuresubscription"]
+  "requires": [ 
+    { "name" : "serviceEndpointId", "type": "connectedService:azureRM" },
+    { "name" : "repositoryName", "type": "string" }
+  ]
 }

--- a/templates/docker-container-webapp.properties.json
+++ b/templates/docker-container-webapp.properties.json
@@ -1,6 +1,6 @@
 {
   "iconName": "docker",
-  "requires": [ 
+  "parameters": [ 
     { "name" : "serviceEndpointId", "type": "connectedService:azureRM", "required": "true" },
     { "name" : "repositoryName", "type": "string", "required": "true" }
   ]

--- a/templates/docker-container-webapp.properties.json
+++ b/templates/docker-container-webapp.properties.json
@@ -1,7 +1,7 @@
 {
   "iconName": "docker",
   "requires": [ 
-    { "name" : "serviceEndpointId", "type": "connectedService:azureRM" },
-    { "name" : "repositoryName", "type": "string" }
+    { "name" : "serviceEndpointId", "type": "connectedService:azureRM", "required": "true" },
+    { "name" : "repositoryName", "type": "string", "required": "true" }
   ]
 }

--- a/templates/docker-container-webapp.properties.json
+++ b/templates/docker-container-webapp.properties.json
@@ -1,4 +1,7 @@
 {
   "iconName": "docker",
-  "requires": [ "azuresubscription"]
+  "requires": [ 
+    { "name" : "serviceEndpointId", "type": "connectedService:azureRM" },
+    { "name" : "repositoryName", "type": "string" }
+  ]
 }


### PR DESCRIPTION
Changing the templates' requires field to a list of required input objects. This will map to the TaskInputDefinition class on the server side. If you look at the actual yaml for these templates, the required inputs are serviceEndpointId and repositoryName. Basically azuresubscription (which is the current required input) is a serviceEndpointId that is of type connectedService:azureRM. On the server, azuresubscription  doesn't map to anything while the other name/type do. 

This additional information will allow us to take in these required inputs and replace them in the templates to get a complete yaml. The server side PR will be out after this one is completed.