### PR TITLE
Fix task condition

### DIFF
--- a/templates/python-django.yml
+++ b/templates/python-django.yml
@@ -49,10 +49,10 @@ steps:
 - script: |
     pushd '$(projectRoot)'
     python manage.py test --testrunner xmlrunner.extra.djangotestrunner.XMLTestRunner --no-input
-  condition: succeededOrFailed()
   displayName: 'Run tests'
 
 - task: PublishTestResults@2
   inputs:
     testResultsFiles: "**/TEST-*.xml"
     testRunTitle: 'Python $(PYTHON_VERSION)'
+  condition: succeededOrFailed()


### PR DESCRIPTION
Moves the `succeededOrFailed()` condition to the correct task.