### PR TITLE
Fixing parameter names in properties.json files

### DIFF
--- a/templates/docker-container-functionapp.properties.json
+++ b/templates/docker-container-functionapp.properties.json
@@ -1,7 +1,7 @@
 {
   "iconName": "functionapp",
   "parameters": [ 
-    { "name" : "serviceEndpointId", "type": "connectedService:azureRM", "required": "true" },
+    { "name" : "azureServiceConnectionId", "type": "connectedService:azureRM", "required": "true" },
     { "name" : "repositoryName", "type": "string", "required": "true" }
   ]
 }

--- a/templates/docker-container-to-acr.properties.json
+++ b/templates/docker-container-to-acr.properties.json
@@ -1,7 +1,7 @@
 {
   "iconName": "docker",
   "parameters": [ 
-    { "name" : "serviceEndpointId", "type": "connectedService:azureRM", "required": "true" },
+    { "name" : "azureServiceConnectionId", "type": "connectedService:azureRM", "required": "true" },
     { "name" : "repositoryName", "type": "string", "required": "true" }
   ]
 }

--- a/templates/docker-container-to-aks.properties.json
+++ b/templates/docker-container-to-aks.properties.json
@@ -1,7 +1,7 @@
 {
   "iconName": "aks",
   "parameters": [ 
-    { "name" : "serviceEndpointId", "type": "connectedService:azureRM", "required": "true" },
+    { "name" : "azureServiceConnectionId", "type": "connectedService:azureRM", "required": "true" },
     { "name" : "repositoryName", "type": "string", "required": "true" }
   ]
 }

--- a/templates/docker-container-webapp.properties.json
+++ b/templates/docker-container-webapp.properties.json
@@ -1,7 +1,7 @@
 {
   "iconName": "docker",
   "parameters": [ 
-    { "name" : "serviceEndpointId", "type": "connectedService:azureRM", "required": "true" },
+    { "name" : "azureServiceConnectionId", "type": "connectedService:azureRM", "required": "true" },
     { "name" : "repositoryName", "type": "string", "required": "true" }
   ]
 }


### PR DESCRIPTION
The properties.json mentions it requires a parameter called `serviceEndpointId` but the yaml uses `azureServiceConnectionId`.
This PR fixes that.