### PR TITLE
Fix appxPackageDir variable in UWP template

### DIFF
--- a/templates/universal-windows-platform.yml
+++ b/templates/universal-windows-platform.yml
@@ -13,7 +13,7 @@ variables:
   solution: '**/*.sln'
   buildPlatform: 'x86|x64|ARM'
   buildConfiguration: 'Release'
-  appxPackageDir: '$(build.artifactStagingDirectory)\AppxPackages\'
+  appxPackageDir: '$(build.artifactStagingDirectory)\AppxPackages\\'
 
 steps:
 - task: NuGetToolInstaller@0


### PR DESCRIPTION
Fix the appxPackageDir variable in the UWP yaml template by adding a trailing slash