### PR TITLE
Adding upload: statement to templates.

### DIFF
--- a/templates/.net-desktop.yml
+++ b/templates/.net-desktop.yml
@@ -31,3 +31,5 @@ steps:
   inputs:
     platform: '$(buildPlatform)'
     configuration: '$(buildConfiguration)'
+
+- upload: '**/bin/{$buildConfiguration}'

--- a/templates/android.yml
+++ b/templates/android.yml
@@ -18,3 +18,5 @@ steps:
     publishJUnitResults: false
     testResultsFiles: '**/TEST-*.xml'
     tasks: 'assembleDebug'
+
+- upload:

--- a/templates/ant.yml
+++ b/templates/ant.yml
@@ -19,3 +19,5 @@ steps:
     jdkArchitectureOption: 'x64'
     publishJUnitResults: false
     testResultsFiles: '**/TEST-*.xml'
+
+- upload:

--- a/templates/asp.net-core-.net-framework.yml
+++ b/templates/asp.net-core-.net-framework.yml
@@ -32,3 +32,5 @@ steps:
   inputs:
     platform: '$(buildPlatform)'
     configuration: '$(buildConfiguration)'
+
+- upload:

--- a/templates/asp.net-core.yml
+++ b/templates/asp.net-core.yml
@@ -15,3 +15,5 @@ variables:
 steps:
 - script: dotnet build --configuration $(buildConfiguration)
   displayName: 'dotnet build $(buildConfiguration)'
+
+- upload:

--- a/templates/asp.net.yml
+++ b/templates/asp.net.yml
@@ -32,3 +32,5 @@ steps:
   inputs:
     platform: '$(buildPlatform)'
     configuration: '$(buildConfiguration)'
+
+- upload:

--- a/templates/empty.yml
+++ b/templates/empty.yml
@@ -17,3 +17,5 @@ steps:
     echo Add other tasks to build, test, and deploy your project.
     echo See https://aka.ms/yaml
   displayName: 'Run a multi-line script'
+
+- upload:

--- a/templates/gcc.yml
+++ b/templates/gcc.yml
@@ -13,3 +13,5 @@ steps:
 - script: |
     make
   displayName: 'make'
+
+- upload:

--- a/templates/go.yml
+++ b/templates/go.yml
@@ -37,3 +37,5 @@ steps:
     go build -v .
   workingDirectory: '$(modulePath)'
   displayName: 'Get dependencies, then build'
+
+- upload:

--- a/templates/gradle.yml
+++ b/templates/gradle.yml
@@ -21,3 +21,5 @@ steps:
     publishJUnitResults: false
     testResultsFiles: '**/TEST-*.xml'
     tasks: 'build'
+
+- upload:

--- a/templates/html.yml
+++ b/templates/html.yml
@@ -14,4 +14,5 @@ steps:
   inputs:
     rootFolderOrFile: '$(build.sourcesDirectory)'
     includeRootFolder: false
-- task: PublishBuildArtifacts@1
+
+- upload:

--- a/templates/maven.yml
+++ b/templates/maven.yml
@@ -20,3 +20,5 @@ steps:
     publishJUnitResults: false
     testResultsFiles: '**/surefire-reports/TEST-*.xml'
     goals: 'package'
+
+- upload:

--- a/templates/node.js-with-angular.yml
+++ b/templates/node.js-with-angular.yml
@@ -20,3 +20,5 @@ steps:
     npm install
     ng build --prod
   displayName: 'npm install and build'
+
+- upload:

--- a/templates/node.js-with-grunt.yml
+++ b/templates/node.js-with-grunt.yml
@@ -19,3 +19,5 @@ steps:
     npm install
     grunt --gruntfile Gruntfile.js
   displayName: 'npm install and run grunt'
+
+- upload:

--- a/templates/node.js-with-gulp.yml
+++ b/templates/node.js-with-gulp.yml
@@ -19,3 +19,5 @@ steps:
     npm install
     gulp default --gulpfile gulpfile.js
   displayName: 'npm install and run gulp'
+
+- upload:

--- a/templates/node.js-with-react.yml
+++ b/templates/node.js-with-react.yml
@@ -19,3 +19,5 @@ steps:
     npm install
     npm run build
   displayName: 'npm install and build'
+
+- upload:

--- a/templates/node.js-with-vue.yml
+++ b/templates/node.js-with-vue.yml
@@ -19,3 +19,5 @@ steps:
     npm install
     npm run build
   displayName: 'npm install and build'
+
+- upload:

--- a/templates/node.js-with-webpack.yml
+++ b/templates/node.js-with-webpack.yml
@@ -20,3 +20,5 @@ steps:
     npm install
     npx webpack --config webpack.config.js
   displayName: 'npm install, run webpack'
+
+- upload:

--- a/templates/node.js.yml
+++ b/templates/node.js.yml
@@ -19,3 +19,5 @@ steps:
     npm install
     npm run build
   displayName: 'npm install and build'
+
+- upload:

--- a/templates/php.yml
+++ b/templates/php.yml
@@ -24,3 +24,5 @@ steps:
 
 - script: composer install --no-interaction --prefer-dist
   displayName: 'composer install'
+
+- upload:

--- a/templates/python-django.yml
+++ b/templates/python-django.yml
@@ -56,3 +56,5 @@ steps:
     testResultsFiles: "**/TEST-*.xml"
     testRunTitle: 'Python $(PYTHON_VERSION)'
   condition: succeededOrFailed()
+
+- upload:

--- a/templates/python-package.yml
+++ b/templates/python-package.yml
@@ -34,3 +34,5 @@ steps:
     pip install pytest pytest-azurepipelines
     pytest
   displayName: 'pytest'
+
+- upload:

--- a/templates/ruby.yml
+++ b/templates/ruby.yml
@@ -21,3 +21,5 @@ steps:
 
 - script: bundle exec rake
   displayName: 'bundle exec rake'
+
+- upload:

--- a/templates/universal-windows-platform.yml
+++ b/templates/universal-windows-platform.yml
@@ -28,3 +28,5 @@ steps:
     solution: '$(solution)'
     configuration: '$(buildConfiguration)'
     msbuildArgs: '/p:AppxBundlePlatforms="$(buildPlatform)" /p:AppxPackageDir="$(appxPackageDir)" /p:AppxBundle=Always /p:UapAppxPackageBuildMode=StoreUpload'
+
+- upload:

--- a/templates/xamarin.android.yml
+++ b/templates/xamarin.android.yml
@@ -25,3 +25,5 @@ steps:
     projectFile: '**/*droid*.csproj'
     outputDirectory: '$(outputDirectory)'
     configuration: '$(buildConfiguration)'
+
+- upload:

--- a/templates/xamarin.ios.yml
+++ b/templates/xamarin.ios.yml
@@ -30,3 +30,5 @@ steps:
     configuration: 'Release'
     buildForSimulator: true
     packageApp: false
+
+- upload:

--- a/templates/xcode.yml
+++ b/templates/xcode.yml
@@ -18,3 +18,5 @@ steps:
     configuration: 'Release'
     xcWorkspacePath: '**/*.xcodeproj/project.xcworkspace'
     xcodeVersion: 'default' # Options: 8, 9, 10, default, specifyPath
+
+- upload:


### PR DESCRIPTION
This is an initial pass at getting the ```upload:``` statement into the YAML templates. For discussion at this stage and we'll merge it once any issues are ironed out. I've updated almost all templates with a single ```- upload:``` statement that uploads the entire working directory (sans the ```.git``` folder). The artifact name will be automatically generated based on the job name (this work is in progress, and if we don't get it in time we'll need to hardcode the artifact name to avoid breaking builds when we do implement automatic artifact naming.