### PR TITLE
[DeployToK8s] Creating secret in correct namespace

### DIFF
--- a/templates/deploy-to-existing-kubernetes-cluster.properties.json
+++ b/templates/deploy-to-existing-kubernetes-cluster.properties.json
@@ -1,5 +1,5 @@
 {
-    "iconName": "k8s",
+    "iconName": "aks",
     "parameters": [
         {
             "name": "kubernetesConnection",

--- a/templates/deploy-to-existing-kubernetes-cluster.yml
+++ b/templates/deploy-to-existing-kubernetes-cluster.yml
@@ -59,6 +59,7 @@ stages:
             inputs:
               action: createSecret
               secretName: $(imagePullSecret)
+              namespace: $(k8sNamespace)
               dockerRegistryEndpoint: $(dockerRegistryServiceConnection)
               
           - task: KubernetesManifest@0

--- a/templates/deploy-to-existing-kubernetes-cluster.yml
+++ b/templates/deploy-to-existing-kubernetes-cluster.yml
@@ -1,4 +1,4 @@
-# Deploy to Kubernetes
+# Deploy to Azure Kubernetes Service
 # Build a Docker image, push to an Azure Container Registry, and deploy it to Azure Kubernetes Service.
 # https://docs.microsoft.com/azure/devops/pipelines/languages/docker
 

--- a/templates/deploy-to-existing-kubernetes-cluster.yml
+++ b/templates/deploy-to-existing-kubernetes-cluster.yml
@@ -1,4 +1,4 @@
-# Deploy to Azure Kubernetes Service
+# Deploy to Azure Kubernetes Service (AKS)
 # Build a Docker image, push to an Azure Container Registry, and deploy it to Azure Kubernetes Service.
 # https://docs.microsoft.com/azure/devops/pipelines/languages/docker
 


### PR DESCRIPTION
Fixes a bug in the template. 
The deploy job was creating the imagePullSecret in `default` namespace when it should have been created in `$(k8sNamespace)`

Updates the title of the template from `Deploy to Kubernetes` to `Deploy to Azure Kubernetes Service (AKS)`