### PR TITLE
Updated name of vm image in node.js-with-react.yml

### DIFF
--- a/templates/node.js-with-react.yml
+++ b/templates/node.js-with-react.yml
@@ -7,7 +7,7 @@ trigger:
 - master
 
 pool:
-  vmImage: 'ubuntu-latest'
+  vmImage: 'ubuntu-16.04'
 
 steps:
 - task: NodeTool@0


### PR DESCRIPTION
ubuntu-latest is not a valid image identifier, replaced with ubuntu 16.04 as specified [here](https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops#use-a-microsoft-hosted-agent)