### PR TITLE
Fixing manifest extension to YML and removing kubernetesConnection as required parameter

### DIFF
--- a/templates/deploy-to-existing-kubernetes-cluster.properties.json
+++ b/templates/deploy-to-existing-kubernetes-cluster.properties.json
@@ -2,11 +2,6 @@
     "iconName": "aks",
     "parameters": [
         {
-            "name": "kubernetesConnection",
-            "type": "endpoint:kubernetes",
-            "required": "true"
-        },
-        {
             "name": "k8sResource",
             "type": "environmentResource:kubernetes",
             "required": "true"

--- a/templates/deploy-to-existing-kubernetes-cluster.yml
+++ b/templates/deploy-to-existing-kubernetes-cluster.yml
@@ -81,7 +81,7 @@ stages:
               action: deploy
               namespace: $(k8sNamespace)
               manifests: |
-                $(System.ArtifactsDirectory)/manifests/*
+                $(System.ArtifactsDirectory)/manifests/*.yml
               imagePullSecrets: |
                 $(imagePullSecret)
               containers: |


### PR DESCRIPTION
`kubernetesConnection` is removed as a required paramter since it is no longer referred  in template