### PR TITLE
Update node.js and java templates

### DIFF
--- a/templates/deploy-to-existing-kubernetes-cluster.yml
+++ b/templates/deploy-to-existing-kubernetes-cluster.yml
@@ -40,11 +40,8 @@ stages:
         tags: |
           $(tag)
           
-    - task: PublishPipelineArtifact@0
-      displayName: Publish manifest files
-      inputs:
-        artifactName: 'manifests'
-        targetPath: 'manifests'
+    - upload: manifests
+      artifact: manifests
 
 - stage: Deploy
   displayName: Deploy stage
@@ -71,8 +68,8 @@ stages:
             inputs:
               action: deploy
               manifests: |
-                $(System.ArtifactsDirectory)/manifests/deployment.yml
-                $(System.ArtifactsDirectory)/manifests/service.yml
+                $(Pipeline.Workspace)/manifests/deployment.yml
+                $(Pipeline.Workspace)/manifests/service.yml
               imagePullSecrets: |
                 $(imagePullSecret)
               containers: |

--- a/templates/maven-webapp-to-linux-on-azure.yml
+++ b/templates/maven-webapp-to-linux-on-azure.yml
@@ -39,10 +39,8 @@ stages:
         Contents: '**/target/*.?(war|jar)'
         TargetFolder: $(Build.ArtifactStagingDirectory)
 
-    - task: PublishPipelineArtifact@0
-      displayName: 'Publish pipeline artifacts'
-      inputs:
-        targetPath: $(Build.ArtifactStagingDirectory)
+    - upload: $(Build.ArtifactStagingDirectory)/$(Build.BuildId).zip
+      artifact: drop
 
 - stage: Deploy
   displayName: Deploy stage
@@ -58,15 +56,10 @@ stages:
       runOnce:
         deploy:
           steps:
-          - task: DownloadPipelineArtifact@1
-            displayName: 'Download Pipeline Artifact'
-            inputs:
-              buildType: 'current'
-
           - task: AzureWebApp@1
             displayName: 'Azure Web App Deploy: {{ webAppName }}'
             inputs:
               azureSubscription: $(azureSubscription)
               appType: webAppLinux
               appName: $(webAppName)
-              package: '$(System.ArtifactsDirectory)/drop/**/target/*.?(war|jar)'
+              package: '$(Pipeline.Workspace)/drop/**/target/*.?(war|jar)'

--- a/templates/maven-webapp-to-linux-on-azure.yml
+++ b/templates/maven-webapp-to-linux-on-azure.yml
@@ -39,7 +39,7 @@ stages:
         Contents: '**/target/*.?(war|jar)'
         TargetFolder: $(Build.ArtifactStagingDirectory)
 
-    - upload: $(Build.ArtifactStagingDirectory)/$(Build.BuildId).zip
+    - upload: $(Build.ArtifactStagingDirectory)
       artifact: drop
 
 - stage: Deploy

--- a/templates/node.js-express-webapp-to-linux-on-azure.yml
+++ b/templates/node.js-express-webapp-to-linux-on-azure.yml
@@ -47,10 +47,8 @@ stages:
         archiveFile: $(Build.ArtifactStagingDirectory)/$(Build.BuildId).zip
         replaceExistingArchive: true
 
-    - task: PublishPipelineArtifact@0
-      displayName: 'Publish pipeline artifacts'
-      inputs:
-        targetPath: $(Build.ArtifactStagingDirectory)/$(Build.BuildId).zip
+    - upload: $(Build.ArtifactStagingDirectory)/$(Build.BuildId).zip
+      artifact: drop
 
 - stage: Deploy
   displayName: Deploy stage
@@ -65,12 +63,7 @@ stages:
     strategy:
       runOnce:
         deploy:
-          steps:
-          - task: DownloadPipelineArtifact@1
-            displayName: 'Download Pipeline Artifact'
-            inputs:
-              buildType: 'current'
-            
+          steps:            
           - task: AzureWebApp@1
             displayName: 'Azure Web App Deploy: {{ webAppName }}'
             inputs:
@@ -78,5 +71,5 @@ stages:
               appType: webAppLinux
               appName: $(webAppName)
               runtimeStack: 'NODE|10.10'
-              package: $(System.ArtifactsDirectory)/drop/$(Build.BuildId).zip
+              package: $(Pipeline.Workspace)/drop/$(Build.BuildId).zip
               startUpCommand: 'npm run start'

--- a/templates/node.js-functionapp-to-linux-on-azure.yml
+++ b/templates/node.js-functionapp-to-linux-on-azure.yml
@@ -48,10 +48,8 @@ stages:
         archiveFile: $(Build.ArtifactStagingDirectory)/$(Build.BuildId).zip
         replaceExistingArchive: true
 
-    - task: PublishPipelineArtifact@0
-      displayName: 'Publish pipeline artifacts'
-      inputs:
-        targetPath: $(Build.ArtifactStagingDirectory)/$(Build.BuildId).zip
+    - upload: $(Build.ArtifactStagingDirectory)/$(Build.BuildId).zip
+      artifact: drop
 
 - stage: Deploy
   displayName: Deploy stage
@@ -66,16 +64,11 @@ stages:
     strategy:
       runOnce:
         deploy:
-          steps:
-          - task: DownloadPipelineArtifact@1
-            displayName: 'Download Pipeline Artifact'
-            inputs:
-              buildType: current
-            
+          steps:            
           - task: AzureFunctionApp@1
             displayName: 'Azure Functions App Deploy: {{ functionAppName }}'
             inputs:
               azureSubscription: '$(azureSubscription)'
               appType: functionAppLinux
               appName: $(functionAppName)
-              package: '$(System.ArtifactsDirectory)/drop/$(Build.BuildId).zip'
+              package: '$(Pipeline.Workspace)/drop/$(Build.BuildId).zip'

--- a/templates/node.js-functionapp-to-linux-on-azure.yml
+++ b/templates/node.js-functionapp-to-linux-on-azure.yml
@@ -33,11 +33,17 @@ stages:
       displayName: 'Install Node.js'
 
     - script: |
-        dotnet build extensions.csproj --runtime ubuntu.16.04-x64 --output ./bin/
+        if [ -f extensions.csproj ]
+        then
+            dotnet build extensions.csproj --runtime ubuntu.16.04-x64 --output ./bin
+        fi
+      displayName: 'Build extensions'
+
+    - script: |
         npm install
         npm run build --if-present
         npm run test --if-present
-      displayName: 'Build extensions and prepare binaries'
+      displayName: 'Prepare binaries'
       
     - task: ArchiveFiles@2
       displayName: 'Archive files'

--- a/templates/node.js-react-webapp-to-linux-on-azure.yml
+++ b/templates/node.js-react-webapp-to-linux-on-azure.yml
@@ -36,10 +36,8 @@ stages:
         archiveFile: $(Build.ArtifactStagingDirectory)/$(Build.BuildId).zip
         replaceExistingArchive: true
 
-    - task: PublishPipelineArtifact@0
-      displayName: 'Publish pipeline artifacts'
-      inputs:
-        targetPath: $(Build.ArtifactStagingDirectory)/$(Build.BuildId).zip
+    - upload: $(Build.ArtifactStagingDirectory)/$(Build.BuildId).zip
+      artifact: drop
 
 - stage: Deploy
   displayName: Deploy stage
@@ -54,19 +52,14 @@ stages:
     strategy:
       runOnce:
         deploy:
-          steps:
-          - task: DownloadPipelineArtifact@1
-            displayName: 'Download Pipeline Artifact'
-            inputs:
-              buildType: current
-            
+          steps:            
           - task: AzureRmWebAppDeployment@4
             displayName: 'Azure App Service Deploy: {{ webAppName }}'
             inputs:
               azureSubscription: $(azureSubscription)
               appType: webAppLinux
               WebAppName: $(webAppName)
-              packageForLinux: '$(System.ArtifactsDirectory)/drop/$(Build.BuildId).zip'
+              packageForLinux: '$(Pipeline.Workspace)/drop/$(Build.BuildId).zip'
               RuntimeStack: 'NODE|10.10'
               StartupCommand: 'npm run start'
               ScriptType: 'Inline Script'


### PR DESCRIPTION
Update node.js and java templates:
- replace publish artifact by upload shortcut
- remove download artifact step as it is auto-injected in deployment job
- build extensions conditionally in node.js function app