### PR TITLE
Update maven.yml to allow publishing test results by default

### DIFF
--- a/templates/maven.yml
+++ b/templates/maven.yml
@@ -17,6 +17,6 @@ steps:
     javaHomeOption: 'JDKVersion'
     jdkVersionOption: '1.8'
     jdkArchitectureOption: 'x64'
-    publishJUnitResults: false
+    publishJUnitResults: true
     testResultsFiles: '**/surefire-reports/TEST-*.xml'
     goals: 'package'


### PR DESCRIPTION
Maven3 task does not log a warning if no test results are found. There could be a slight perf impact looking for the test files but the benefit customers get via rich test result reporting we think outweighs the additional time added to the run. 