### PR TITLE
Use recommended labels in kubernetes deployment and service

### DIFF
--- a/templates/resources/k8s/deployment.yml
+++ b/templates/resources/k8s/deployment.yml
@@ -1,16 +1,20 @@
 apiVersion : apps/v1beta1
 kind: Deployment
 metadata:
-  name: {{ imageRepository }} 
+  name: {{ imageRepository }}
+  labels:
+    app.kubernetes.io/name: {{ imageRepository }}
+    app.kubernetes.io/managed-by: azure-pipelines
 spec:
   replicas: 1
   template:
     metadata:
       labels:
-        app: {{ imageRepository }} 
+        app.kubernetes.io/name: {{ imageRepository }}
+        app.kubernetes.io/managed-by: azure-pipelines
     spec:
       containers:
-        - name: {{ imageRepository }} 
-          image: {{ containerRegistryConnection.Authorization.Parameters.loginServer }}/{{ imageRepository }} 
-          ports:
-          - containerPort: {{ servicePort }}
+      - name: {{ imageRepository }}
+        image: {{ containerRegistryConnection.Authorization.Parameters.loginServer }}/{{ imageRepository }}
+        ports:
+        - containerPort: {{ servicePort }}

--- a/templates/resources/k8s/service.yml
+++ b/templates/resources/k8s/service.yml
@@ -1,10 +1,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-    name: {{ imageRepository }}
+  name: {{ imageRepository }}
+  labels:
+    app.kubernetes.io/name: {{ imageRepository }}
+    app.kubernetes.io/managed-by: azure-pipelines
 spec:
-    type: LoadBalancer
-    ports:
-    - port: {{ servicePort }} 
-    selector:
-        app: {{ imageRepository }}
+  type: LoadBalancer
+  ports:
+  - port: {{ servicePort }}
+  selector:
+    app.kubernetes.io/name: {{ imageRepository }}


### PR DESCRIPTION
As specified in the [kubernetes recommended labels documentation](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/), `app.kubernetes.io/name` should be used as a label key instead of "app".

Also, I added the `app.kubernetes.io/managed-by` label to the service and deployment because it seemed like the only other recommended label that I could easily populate.