### PR TITLE
Adding display names for parameters that are missing them

### DIFF
--- a/templates/deploy-to-existing-kubernetes-cluster.properties.json
+++ b/templates/deploy-to-existing-kubernetes-cluster.properties.json
@@ -4,12 +4,14 @@
         {
             "name": "k8sResource",
             "type": "environmentResource:kubernetes",
-            "required": "true"
+            "required": "true",
+            "displayName": "Kubernetes Resource"
         },
         {
             "name": "containerRegistryConnection",
             "type": "endpoint:containerRegistry",
-            "required": "true"
+            "required": "true",
+            "displayName": "Container Registry"
         },
         {
             "name": "imageRepository",

--- a/templates/docker-container.properties.json
+++ b/templates/docker-container.properties.json
@@ -4,7 +4,8 @@
     {
       "name": "containerRegistryConnection",
       "type": "endpoint:containerRegistry",
-      "required": "true"
+      "required": "true",
+      "displayName": "Container Registry"
     },
     {
       "name": "imageRepository",

--- a/templates/maven-webapp-to-linux-on-azure.properties.json
+++ b/templates/maven-webapp-to-linux-on-azure.properties.json
@@ -4,7 +4,8 @@
         {
             "name": "azureRmConnection",
             "type": "endpoint:azureRm",
-            "required": "true"
+            "required": "true",
+            "displayName": "Azure Connection"
         },
         {
             "name": "webAppName",

--- a/templates/node.js-express-webapp-to-linux-on-azure.properties.json
+++ b/templates/node.js-express-webapp-to-linux-on-azure.properties.json
@@ -4,7 +4,8 @@
         {
             "name": "azureRmConnection",
             "type": "endpoint:azureRm",
-            "required": "true"
+            "required": "true",
+            "displayName": "Azure Connection"
         },
         {
             "name": "webAppName",

--- a/templates/node.js-functionapp-to-linux-on-azure.properties.json
+++ b/templates/node.js-functionapp-to-linux-on-azure.properties.json
@@ -4,7 +4,8 @@
         {
             "name": "azureRmConnection",
             "type": "endpoint:azureRm",
-            "required": "true"
+            "required": "true",
+            "displayName": "Azure Connection"
         },
         {
             "name": "functionAppName",

--- a/templates/node.js-react-webapp-to-linux-on-azure.properties.json
+++ b/templates/node.js-react-webapp-to-linux-on-azure.properties.json
@@ -4,7 +4,8 @@
         {
             "name": "azureRmConnection",
             "type": "endpoint:azureRm",
-            "required": "true"
+            "required": "true",
+            "displayName": "Azure Connection"
         },
         {
             "name": "webAppName",


### PR DESCRIPTION
These types have custom UI and so don't show these names, but the code that serves them from the backend doesn't know that and it flags them as missing names via debugger break.  This is annoying, so let's just give them some names.