### PR TITLE
Fix checkout path name

### DIFF
--- a/design/multicheckout.md
+++ b/design/multicheckout.md
@@ -112,7 +112,7 @@ resources:
 
 steps:
 - checkout: self
-  root: module1
+  path: module1
 - checkout: code2
   path: module2
 - checkout: code3


### PR DESCRIPTION
It *appears* that `root` was inconsistently used here and that `path` was probably what was intended.

Please confirm before completing PR.

If this *was* correct before my change, there lacks any explanation or docs that I can find for what `root` means.