### PR TITLE
Update Gradle.yml to enable test publishing by default

### DIFF
--- a/templates/gradle.yml
+++ b/templates/gradle.yml
@@ -18,6 +18,6 @@ steps:
     javaHomeOption: 'JDKVersion'
     jdkVersionOption: '1.8'
     jdkArchitectureOption: 'x64'
-    publishJUnitResults: false
+    publishJUnitResults: true
     testResultsFiles: '**/TEST-*.xml'
     tasks: 'build'


### PR DESCRIPTION
Similar to the following PR: https://github.com/microsoft/azure-pipelines-yaml/pull/242

Many customers are not aware of rich test result functionality being available. This will enable test results to show up by default.