### PR TITLE
Update ant.yml to enable test results by default

### DIFF
--- a/templates/ant.yml
+++ b/templates/ant.yml
@@ -17,5 +17,5 @@ steps:
     javaHomeOption: 'JDKVersion'
     jdkVersionOption: '1.8'
     jdkArchitectureOption: 'x64'
-    publishJUnitResults: false
+    publishJUnitResults: true
     testResultsFiles: '**/TEST-*.xml'


### PR DESCRIPTION
Similar to the following PR: #242

Many customers are not aware of rich test result functionality being available. This will enable test results to show up by default.