### PR TITLE
Use options instead of mavenOptions for Maven task

### DIFF
--- a/templates/maven.yml
+++ b/templates/maven.yml
@@ -13,7 +13,7 @@ steps:
 - task: Maven@3
   inputs:
     mavenPomFile: 'pom.xml'
-    mavenOptions: '-Xmx3072m'
+    options: '-Xmx3072m'
     javaHomeOption: 'JDKVersion'
     jdkVersionOption: '1.8'
     jdkArchitectureOption: 'x64'


### PR DESCRIPTION
This avoids overriding the globally defined MAVEN_OPTS which breaks caching for example (https://docs.microsoft.com/en-us/azure/devops/pipelines/release/caching?view=azure-devops#maven).