### PR TITLE
Update deployment.yml to apps/v1 from apps/v1beta1 so that it works on aks clusters created without specifying older versions of kubernetes.

### DIFF
--- a/templates/resources/k8s/deployment.yml
+++ b/templates/resources/k8s/deployment.yml
@@ -1,9 +1,12 @@
-apiVersion : apps/v1beta1
+apiVersion : apps/v1
 kind: Deployment
 metadata:
   name: {{#toAlphaNumericString imageRepository 50}}{{/toAlphaNumericString}} 
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: {{#toAlphaNumericString imageRepository 50}}{{/toAlphaNumericString}} 
   template:
     metadata:
       labels:


### PR DESCRIPTION
This is a proposed fix for #508

When following the instructions for [Build and deploy to Azure Kubernetes Service](https://docs.microsoft.com/en-us/azure/devops/pipelines/ecosystems/kubernetes/aks-template?view=azure-devops) even by following the instructions exactly it will cause a fail on deployment due to changes in the kubernetes api on newer version of AKS.

My change will update the manifest version that will work on newer versions of Kubernetes that get created by default when not specifying the version and creating an aks cluster. I would propose an optional change to the documentation as well to specify a version so that in the future this wouldn't cause examples to no longer work as the api changes and can be seen at [my PR here](https://github.com/MicrosoftDocs/azure-devops-docs/pull/8988)