### PR TITLE
Changed api-version to v1 and added matchLabels to deployment spec

### DIFF
--- a/templates/resources/k8s/deployment.yml
+++ b/templates/resources/k8s/deployment.yml
@@ -1,9 +1,12 @@
-apiVersion : apps/v1beta1
+apiVersion : apps/v1
 kind: Deployment
 metadata:
   name: {{#toAlphaNumericString imageRepository 50}}{{/toAlphaNumericString}} 
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: {{#toAlphaNumericString imageRepository 50}}{{/toAlphaNumericString}}
   template:
     metadata:
       labels:


### PR DESCRIPTION
Upgraded the api-version to `apps/v1` as `apps/v1beta1` got deprecated and is causing the pipeline to fail.