### PR TITLE
change 'main' to '{{ defaultBranch }}'

### DIFF
--- a/templates/.net-desktop.yml
+++ b/templates/.net-desktop.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/apps/windows/dot-net
 
 trigger:
-- main
+- '{{ defaultBranch }}'
 
 pool:
   vmImage: 'windows-latest'

--- a/templates/android.yml
+++ b/templates/android.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/android
 
 trigger:
-- main
+- '{{ defaultBranch }}'
 
 pool:
   vmImage: 'macos-latest'

--- a/templates/ant.yml
+++ b/templates/ant.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/java
 
 trigger:
-- main
+- '{{ defaultBranch }}'
 
 pool:
   vmImage: 'ubuntu-latest'

--- a/templates/asp.net-core-.net-framework.yml
+++ b/templates/asp.net-core-.net-framework.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/dotnet-core
 
 trigger:
-- main
+- '{{ defaultBranch }}'
 
 pool:
   vmImage: 'windows-latest'

--- a/templates/asp.net-core-functionapp-to-windows-on-azure.yml
+++ b/templates/asp.net-core-functionapp-to-windows-on-azure.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/en-us/azure/devops/pipelines/languages/dotnet-core
 
 trigger:
-- main
+- '{{ defaultBranch }}'
 
 variables:
   # Azure Resource Manager connection created during pipeline creation

--- a/templates/asp.net-core.yml
+++ b/templates/asp.net-core.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/dotnet-core
 
 trigger:
-- main
+- '{{ defaultBranch }}'
 
 pool:
   vmImage: 'ubuntu-latest'

--- a/templates/asp.net.yml
+++ b/templates/asp.net.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/apps/aspnet/build-aspnet-4
 
 trigger:
-- main
+- '{{ defaultBranch }}'
 
 pool:
   vmImage: 'windows-latest'

--- a/templates/deploy-to-existing-kubernetes-cluster-devspaces.yml
+++ b/templates/deploy-to-existing-kubernetes-cluster-devspaces.yml
@@ -3,7 +3,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/docker
 
 trigger:
-- main
+- '{{ defaultBranch }}'
 
 resources:
 - repo: self

--- a/templates/deploy-to-existing-kubernetes-cluster.yml
+++ b/templates/deploy-to-existing-kubernetes-cluster.yml
@@ -3,7 +3,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/docker
 
 trigger:
-- main
+- '{{ defaultBranch }}'
 
 resources:
 - repo: self

--- a/templates/docker-build.yml
+++ b/templates/docker-build.yml
@@ -3,7 +3,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/docker
 
 trigger:
-- main
+- '{{ defaultBranch }}'
 
 resources:
 - repo: self

--- a/templates/docker-container-functionapp.yml
+++ b/templates/docker-container-functionapp.yml
@@ -3,7 +3,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/docker
 
 trigger:
-- main
+- '{{ defaultBranch }}'
 
 resources:
 - repo: self

--- a/templates/docker-container-to-acr.yml
+++ b/templates/docker-container-to-acr.yml
@@ -3,7 +3,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/docker
 
 trigger:
-- main
+- '{{ defaultBranch }}'
 
 resources:
 - repo: self

--- a/templates/docker-container-to-aks.yml
+++ b/templates/docker-container-to-aks.yml
@@ -3,7 +3,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/docker
 
 trigger:
-- main
+- '{{ defaultBranch }}'
 
 resources:
 - repo: self

--- a/templates/docker-container-webapp.yml
+++ b/templates/docker-container-webapp.yml
@@ -3,7 +3,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/docker
 
 trigger:
-- main
+- '{{ defaultBranch }}'
 
 resources:
 - repo: self

--- a/templates/docker-container.yml
+++ b/templates/docker-container.yml
@@ -3,7 +3,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/docker
 
 trigger:
-- main
+- '{{ defaultBranch }}'
 
 resources:
 - repo: self

--- a/templates/empty.yml
+++ b/templates/empty.yml
@@ -4,7 +4,7 @@
 # https://aka.ms/yaml
 
 trigger:
-- main
+- '{{ defaultBranch }}'
 
 pool:
   vmImage: 'ubuntu-latest'

--- a/templates/gcc.yml
+++ b/templates/gcc.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/apps/c-cpp/gcc
 
 trigger:
-- main
+- '{{ defaultBranch }}'
 
 pool:
   vmImage: 'ubuntu-latest'

--- a/templates/go.yml
+++ b/templates/go.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/go
 
 trigger:
-- main
+- '{{ defaultBranch }}'
 
 pool:
   vmImage: 'ubuntu-latest'

--- a/templates/gradle.yml
+++ b/templates/gradle.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/java
 
 trigger:
-- main
+- '{{ defaultBranch }}'
 
 pool:
   vmImage: 'ubuntu-latest'

--- a/templates/html.yml
+++ b/templates/html.yml
@@ -4,7 +4,7 @@
 # https://aka.ms/yaml
 
 trigger:
-- main
+- '{{ defaultBranch }}'
 
 pool:
   vmImage: 'ubuntu-latest'

--- a/templates/jekyll-container.yml
+++ b/templates/jekyll-container.yml
@@ -4,7 +4,7 @@
 # https://aka.ms/yaml
 
 trigger:
-- main
+- '{{ defaultBranch }}'
 
 pool:
   vmImage: 'ubuntu-latest'

--- a/templates/maven-webapp-to-linux-on-azure.yml
+++ b/templates/maven-webapp-to-linux-on-azure.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/java
 
 trigger:
-- main
+- '{{ defaultBranch }}'
 
 variables:
 

--- a/templates/maven.yml
+++ b/templates/maven.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/java
 
 trigger:
-- main
+- '{{ defaultBranch }}'
 
 pool:
   vmImage: 'ubuntu-latest'

--- a/templates/node.js-express-webapp-to-linux-on-azure.yml
+++ b/templates/node.js-express-webapp-to-linux-on-azure.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/javascript
 
 trigger:
-- main
+- '{{ defaultBranch }}'
 
 variables:
 

--- a/templates/node.js-functionapp-to-linux-on-azure.yml
+++ b/templates/node.js-functionapp-to-linux-on-azure.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/javascript
 
 trigger:
-- main
+- '{{ defaultBranch }}'
 
 variables:
 

--- a/templates/node.js-react-webapp-to-linux-on-azure.yml
+++ b/templates/node.js-react-webapp-to-linux-on-azure.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/javascript
 
 trigger:
-- main
+- '{{ defaultBranch }}'
 
 variables:
 

--- a/templates/node.js-with-angular.yml
+++ b/templates/node.js-with-angular.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/javascript
 
 trigger:
-- main
+- '{{ defaultBranch }}'
 
 pool:
   vmImage: 'ubuntu-latest'

--- a/templates/node.js-with-grunt.yml
+++ b/templates/node.js-with-grunt.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/javascript
 
 trigger:
-- main
+- '{{ defaultBranch }}'
 
 pool:
   vmImage: 'ubuntu-latest'

--- a/templates/node.js-with-gulp.yml
+++ b/templates/node.js-with-gulp.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/javascript
 
 trigger:
-- main
+- '{{ defaultBranch }}'
 
 pool:
   vmImage: 'ubuntu-latest'

--- a/templates/node.js-with-react.yml
+++ b/templates/node.js-with-react.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/javascript
 
 trigger:
-- main
+- '{{ defaultBranch }}'
 
 pool:
   vmImage: 'ubuntu-latest'

--- a/templates/node.js-with-vue.yml
+++ b/templates/node.js-with-vue.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/javascript
 
 trigger:
-- main
+- '{{ defaultBranch }}'
 
 pool:
   vmImage: 'ubuntu-latest'

--- a/templates/node.js-with-webpack.yml
+++ b/templates/node.js-with-webpack.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/javascript
 
 trigger:
-- main
+- '{{ defaultBranch }}'
 
 pool:
   vmImage: 'ubuntu-latest'

--- a/templates/node.js.yml
+++ b/templates/node.js.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/javascript
 
 trigger:
-- main
+- '{{ defaultBranch }}'
 
 pool:
   vmImage: 'ubuntu-latest'

--- a/templates/php-webapp-to-linux-on-azure.yml
+++ b/templates/php-webapp-to-linux-on-azure.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/php
 
 trigger:
-- main
+- '{{ defaultBranch }}'
 
 variables:
   # Azure Resource Manager connection created during pipeline creation

--- a/templates/php.yml
+++ b/templates/php.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/php
 
 trigger:
-- main
+- '{{ defaultBranch }}'
 
 pool:
   vmImage: 'ubuntu-latest'

--- a/templates/powershell-functionapp-to-windows-on-azure.yml
+++ b/templates/powershell-functionapp-to-windows-on-azure.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
 
 trigger:
-- main
+- '{{ defaultBranch }}'
 
 variables:
   # Azure Resource Manager connection created during pipeline creation

--- a/templates/python-django.yml
+++ b/templates/python-django.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/python
 
 trigger:
-- main
+- '{{ defaultBranch }}'
 
 pool:
   vmImage: 'ubuntu-latest'

--- a/templates/python-functionapp-to-linux-on-azure.yml
+++ b/templates/python-functionapp-to-linux-on-azure.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/python
 
 trigger:
-- main
+- '{{ defaultBranch }}'
 
 variables:
   # Azure Resource Manager connection created during pipeline creation

--- a/templates/python-package.yml
+++ b/templates/python-package.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/python
 
 trigger:
-- main
+- '{{ defaultBranch }}'
 
 pool:
   vmImage: 'ubuntu-latest'

--- a/templates/python-to-linux-webapp-on-azure.yml
+++ b/templates/python-to-linux-webapp-on-azure.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/python
 
 trigger:
-- main
+- '{{ defaultBranch }}'
 
 variables:
   # Azure Resource Manager connection created during pipeline creation

--- a/templates/ruby.yml
+++ b/templates/ruby.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/ruby
 
 trigger:
-- main
+- '{{ defaultBranch }}'
 
 pool:
   vmImage: 'ubuntu-latest'

--- a/templates/universal-windows-platform.yml
+++ b/templates/universal-windows-platform.yml
@@ -4,7 +4,7 @@
 # https://aka.ms/yaml
 
 trigger:
-- main
+- '{{ defaultBranch }}'
 
 pool:
   vmImage: 'windows-latest'

--- a/templates/xamarin.android.yml
+++ b/templates/xamarin.android.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/xamarin
 
 trigger:
-- main
+- '{{ defaultBranch }}'
 
 pool:
   vmImage: 'macos-latest'

--- a/templates/xamarin.ios.yml
+++ b/templates/xamarin.ios.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/xamarin
 
 trigger:
-- main
+- '{{ defaultBranch }}'
 
 pool:
   vmImage: 'macos-latest'

--- a/templates/xcode.yml
+++ b/templates/xcode.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/xcode
 
 trigger:
-- main
+- '{{ defaultBranch }}'
 
 pool:
   vmImage: 'macos-latest'


### PR DESCRIPTION
"In their current form, the YAML pipeline templates hardcode "master" as the default triggering branch. Now that customers can specify their default branch, we should be able to leave that as a symbol in the template and have the setup wizard replace it with the actual (or chosen) default branch name."
https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/1765369