### PR TITLE
Removed blue-green strategy from docs

### DIFF
--- a/design/deployment.md
+++ b/design/deployment.md
@@ -29,8 +29,6 @@ jobs:
         displayName: string # friendly name to display in the UI
         steps: [ script | bash | pwsh | powershell | checkout | task | templateReference ]
 ```
-> Note: At the moment we offer only the *runOnce* strategy, which executes the steps once sequentially. Additional strategies like blue-green, canary and rolling are on our roadmap.
-
 
 Following properties are on hold
 ```yaml


### PR DESCRIPTION
Removed blue-green strategy from docs - since it's obsolete.
Up-to-date docs - https://docs.microsoft.com/en-us/azure/devops/pipelines/process/deployment-jobs?view=azure-devops
