### PR TITLE
Fix incorrect environment variable in container-steps.md

### DIFF
--- a/design/deprecated/container-steps.md
+++ b/design/deprecated/container-steps.md
@@ -61,7 +61,7 @@ resources:
 steps:
 - run: dotnet
   env:
-    DOTNET_TELEMETRY_OPT_OUT: true  # add an environment variable
+    DOTNET_CLI_TELEMETRY_OPTOUT: true  # add an environment variable
   cmd: build  # override the default CMD/ENTRYPOINT in the container
 - run: yarn
   workspace: /my/custom/workspace # override the default workspace mapping
@@ -73,7 +73,7 @@ If your container image is from DockerHub, you can skip the forward-declaration 
 ```yaml
 - run: microsoft/dotnet:latest
   env:
-    DOTNET_TELEMETRY_OPT_OUT: true  # add an environment variable
+    DOTNET_CLI_TELEMETRY_OPTOUT: true  # add an environment variable
 - run: facebook/yarn:latest
 ```
 


### PR DESCRIPTION
# Description
This PR replaces the incorrect environment variable DOTNET_TELEMETRY_OPT_OUT in container-steps.md

#### Related issue:
 Incorrect env var DOTNET_TELEMETRY_OPT_OUT usage in container-steps.md (supposed to be DOTNET_CLI_TELEMETRY_OPTOUT) [#564 ](https://github.com/microsoft/azure-pipelines-yaml/issues/564)
