### PR TITLE
Update Node Express template to use 16 LTS

### DIFF
--- a/templates/node.js-express-webapp-to-linux-on-azure.yml
+++ b/templates/node.js-express-webapp-to-linux-on-azure.yml
@@ -32,7 +32,7 @@ stages:
     steps:
     - task: NodeTool@0
       inputs:
-        versionSpec: '10.x'
+        versionSpec: '16.x'
       displayName: 'Install Node.js'
 
     - script: |
@@ -73,6 +73,6 @@ stages:
               azureSubscription: $(azureSubscription)
               appType: webAppLinux
               appName: $(webAppName)
-              runtimeStack: 'NODE|10.10'
+              runtimeStack: 'NODE|16-lts'
               package: $(Pipeline.Workspace)/drop/$(Build.BuildId).zip
               startUpCommand: 'npm run start'


### PR DESCRIPTION
Could you please update the Node.js Express template to use a newer version of Node.js? It's used in our documentation samples.